### PR TITLE
Add support for old playlist editor format

### DIFF
--- a/apps/converter/forms.py
+++ b/apps/converter/forms.py
@@ -4,6 +4,7 @@ from . import lib
 
 class PlaylistForm(forms.Form):
     playlist_url = forms.URLField()
+    format_old = forms.BooleanField(required=False)
 
     def is_valid(self) -> bool:
         # override is_valid so we can make sure playlist_url is a valid Spotify playlist URL

--- a/templates/index.html
+++ b/templates/index.html
@@ -36,6 +36,12 @@
                             </div>
                         </div>
                         <div class="field">
+                            <label class="checkbox">
+                                <input type="checkbox" name="format_old" />
+                                format <span class="is-family-monospace">.csv</span> for WTJU's old playlist editor
+                            </label>
+                        </div>
+                        <div class="field">
                             <div class="control">
                                 <input type="submit" value="convert" class="button is-primary" />
                             </div>


### PR DESCRIPTION
Adds support for converting playlists to the format used by WTJU's "old playlist editor."
The old editor uses a slightly different column layout, but apparently is preferred because the new interface has some bugs.
