### PR TITLE
Use Spotify 'get several albums' endpoint for album info

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,4 +49,4 @@ serverless deploy --stage prod
 - [x] Convert Spotify playlists to old/new playlist editor format
 - [ ] Integrate with a music database to provide information about tracks from local library
     - [ ] ...and solve issues discriminating between composer/performer
-- [ ] Optimize to use Spotify Bulk APIs and avoid ratelimits
+- [x] Optimize to use Spotify Bulk APIs and avoid ratelimits

--- a/backend/wxtj-converter-api/convertlib/__init__.py
+++ b/backend/wxtj-converter-api/convertlib/__init__.py
@@ -108,6 +108,16 @@ def write_new_playlist_csv(spotify: spotipy.Spotify, playlist_id: str, stream: t
     for item in playlist_items["items"]:
         # fetch relevant variables
         track = item["track"]
+
+        # for whatever reason, even when setting additional_items=["track"], Spotify Web API
+        # returns entries for podcast epsiodes. Unfortunately, the response contains no
+        # useful data (like the podcast name), so we just have to give this blanket error message.
+        if track is None:
+            warnings.append(
+                "I couldn't find details on an item in your playlist, so I ignored it. (This could be caused by a podcast episode in your playlist.)")
+            # just skip it
+            continue
+
         # is this track local? (imported from personal library)
         is_local_track = track["is_local"]
         artist = track["artists"][0]  # just get the first artist on the track
@@ -205,6 +215,16 @@ def write_old_playlist_csv(spotify: spotipy.Spotify, playlist_id: str, show_titl
     for item in playlist_items["items"]:
         # fetch relevant variables
         track = item["track"]
+
+        # for whatever reason, even when setting additional_items=["track"], Spotify Web API
+        # returns entries for podcast epsiodes. Unfortunately, the response contains no
+        # useful data (like the podcast name), so we just have to give this blanket error message.
+        if track is None:
+            warnings.append(
+                "I couldn't find details on an item in your playlist, so I ignored it. (This could be caused by a podcast episode in your playlist.)")
+            # just skip it
+            continue
+
         # is this track local? (imported from personal library)
         is_local_track = track["is_local"]
         artist = track["artists"][0]  # just get the first artist on the track

--- a/backend/wxtj-converter-api/convertlib/__init__.py
+++ b/backend/wxtj-converter-api/convertlib/__init__.py
@@ -91,6 +91,10 @@ def _get_bulk_album_info(spotify: spotipy.Spotify, playlist_items: typing.List) 
         if item["track"] is not None and not item["track"]["is_local"]
     ]
 
+    # remove duplicates from list, in case the playlist contains multiple tracks
+    # from the same album.
+    album_ids = list(set(album_ids))
+
     albums = {}
 
     # the 'get several albums' endpoint allows a maximum of 20 album ids per request,

--- a/backend/wxtj-converter-api/test.py
+++ b/backend/wxtj-converter-api/test.py
@@ -69,6 +69,32 @@ class TestPlaylistConverter(unittest.TestCase):
         # and that the playlist name is correct
         self.assertEqual(name, "songs people wrote about their pets")
 
+    def test_new_playlist_converter_local_track_warnings(self):
+        # makes sure there ARE warnings when converting playlists with local tracks
+        playlist_url = "https://open.spotify.com/playlist/4rDiZp82mJm55e0Se3OkpI?si=9c987e7cea6b4458"
+        playlist_id = convertlib.extract_playlist_id_from_url(playlist_url)
+
+        # allocate buffer to contain the converted csv
+        buffer = io.StringIO()
+        _, warnings = convertlib.write_new_playlist_csv(
+            spotify, playlist_id, buffer)
+
+        # make sure there are warnings
+        self.assertNotEqual(warnings, [])
+
+    def test_new_playlist_converter_podcast_warnings(self):
+        # makes sure there ARE warnings when converting playlists containing podcast episodes
+        playlist_url = "https://open.spotify.com/playlist/7a5Ecmgilx7LdsPsGZlkZZ?si=185c9d6e5feb495c"
+        playlist_id = convertlib.extract_playlist_id_from_url(playlist_url)
+
+        # allocate buffer to contain the converted csv
+        buffer = io.StringIO()
+        _, warnings = convertlib.write_new_playlist_csv(
+            spotify, playlist_id, buffer)
+
+        # make sure there are warnings
+        self.assertNotEqual(warnings, [])
+
     def test_old_playlist_converter(self):
         """Tests that the "old playlist editor" converter works without emitting any warnings
         """
@@ -85,6 +111,32 @@ class TestPlaylistConverter(unittest.TestCase):
         self.assertEqual(warnings, [])
         # and that the playlist name is correct
         self.assertEqual(name, "songs people wrote about their pets")
+
+    def test_old_playlist_converter_local_track_warnings(self):
+        # makes sure there ARE warnings when converting playlists with local tracks
+        playlist_url = "https://open.spotify.com/playlist/4rDiZp82mJm55e0Se3OkpI?si=9c987e7cea6b4458"
+        playlist_id = convertlib.extract_playlist_id_from_url(playlist_url)
+
+        # allocate buffer to contain the converted csv
+        buffer = io.StringIO()
+        _, warnings = convertlib.write_old_playlist_csv(
+            spotify, playlist_id, "hot tub listening club", date.today(), buffer)
+
+        # make sure there are warnings
+        self.assertNotEqual(warnings, [])
+
+    def test_old_playlist_converter_podcast_warnings(self):
+        # makes sure there ARE warnings when converting playlists containing podcast episodes
+        playlist_url = "https://open.spotify.com/playlist/7a5Ecmgilx7LdsPsGZlkZZ?si=7301c7c07c0c42e1"
+        playlist_id = convertlib.extract_playlist_id_from_url(playlist_url)
+
+        # allocate buffer to contain the converted csv
+        buffer = io.StringIO()
+        _, warnings = convertlib.write_old_playlist_csv(
+            spotify, playlist_id, "hot tub listening club", date.today(), buffer)
+
+        # make sure there are warnings
+        self.assertNotEqual(warnings, [])
 
 
 class TestUtil(unittest.TestCase):


### PR DESCRIPTION
- Add error message for podcast episodes in playlist
- Expand test coverage for warnings
- Use API 'get several albums' endpoint to cut down on api requests
    - Lets us fetch release year / record label for up to 20 albums in a single request, instead of dispatching 20 individual requests.
